### PR TITLE
Adapt mapSourceURI parameter to Scala 3

### DIFF
--- a/src/main/scala/webscalajs/ScalaJSWeb.scala
+++ b/src/main/scala/webscalajs/ScalaJSWeb.scala
@@ -70,14 +70,19 @@ object ScalaJSWeb extends AutoPlugin {
         else
           Seq.empty
       },
-      linkJS / sourceMappingsToScalacOptions := toScalacOptions,
+      linkJS / sourceMappingsToScalacOptions := toScalacOptions(scalaVersion.value),
       linkJS / sourceMappingsTargetDirectoryName := "scala"
     )
 
-  private def toScalacOptions(sourceMappings: Seq[PathMapping]): Seq[String] =
+  private def toScalacOptions(scalaVersion: String)(sourceMappings: Seq[PathMapping]): Seq[String] =
     for ((file, newPrefix) <- sourceMappings) yield {
+      val optionName =
+        if (ScalaArtifacts.isScala3(scalaVersion))
+          "-scalajs-mapSourceURI"
+        else
+          "-P:scalajs:mapSourceURI"
       val oldPrefix = file.getCanonicalFile.toURI
-      s"-P:scalajs:mapSourceURI:$oldPrefix->../$newPrefix/"
+      s"$optionName:$oldPrefix->../$newPrefix/"
     }
 
   /**


### PR DESCRIPTION
As mentioned in https://github.com/vmunier/sbt-web-scalajs/issues/105 the name of the `mapSourceURI` parameter has changed in Scala 3.
This PR distinguishes by the SBT `scalaVersion` and sets the parameter accordingly.
It's currently hard to write scripted tests for this due to missing Scala 3 dependencies, but I've tested it locally in a project I want to transition to Scala 3.